### PR TITLE
4note autos

### DIFF
--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -47,13 +47,14 @@ void Robot::TeleopInit()
   // continue until interrupted by another command, remove
   // this line or comment it out.
   
-  m_container.ZeroHeading();
-
   if (m_autonomousCommand)
   {
     m_autonomousCommand->Cancel();
     m_autonomousCommand.reset();
   }
+
+  //m_container.ZeroHeading();
+  m_container.ShooterOff();
 }
 
 /**

--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -46,6 +46,8 @@ void Robot::TeleopInit()
   // teleop starts running. If you want the autonomous to
   // continue until interrupted by another command, remove
   // this line or comment it out.
+  
+  m_container.ZeroHeading();
 
   if (m_autonomousCommand)
   {

--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -14,6 +14,7 @@ RobotContainer::RobotContainer()
   m_chooser.AddOption("ShootTobackupRight", "ShootTobackupRight");
   m_chooser.AddOption("ShootTobackupLeft", "ShootTobackupLeft");
   m_chooser.AddOption("Close4", "Close4");
+  m_chooser.AddOption("RedClose4", "RedClose4");
   m_chooser.AddOption("FarSideMid", "FarSideMid");
 
   //paths commented out for now since they are unused
@@ -531,9 +532,10 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand()
       frc2::WaitCommand(0.1_s).ToPtr(),  //This is neccesary because the reset odometry will not actually reset until after a very small amount of time. 
       AutoShooterWarmupCmd(m_shooterWheels).ToPtr(),
       frc2::cmd::Race( //aim shooter for 0.75s
-        AutoAprilTag(m_limelight, m_drive, m_shooter).ToPtr(),
+        //AutoAprilTag(m_limelight, m_drive, m_shooter).ToPtr(),
+        AutoSubAim(m_shooter).ToPtr(),
         frc2::cmd::Sequence(
-          frc2::WaitCommand(0.5_s).ToPtr(), //can change if need
+          frc2::WaitCommand(0.75_s).ToPtr(), //can change if need
           AutoShootCommand(m_shooterWheels, m_intake).ToPtr()
         )
       ),
@@ -569,14 +571,70 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand()
           frc2::WaitCommand(0.75_s).ToPtr(), //can change if need
           AutoShootCommand(m_shooterWheels, m_intake).ToPtr()
         )
+      ),
+      frc2::cmd::RunOnce(
+        [this]
+        {
+          m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
+        },
+        {&m_drive}
       )
-      // frc2::cmd::RunOnce(
-      //   [this]
-      //   {
-      //     m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
-      //   },
-      //   {&m_drive}
-      // )
+    );
+  }
+  else if(chosenAuto == "RedClose4")
+  {
+    m_drive.ResetOdometry(redClose4Waypoint1[0]);
+    return frc2::cmd::Sequence( //the whole auto path!
+      frc2::WaitCommand(0.1_s).ToPtr(),  //This is neccesary because the reset odometry will not actually reset until after a very small amount of time. 
+      AutoShooterWarmupCmd(m_shooterWheels).ToPtr(),
+      frc2::cmd::Race( //aim shooter for 0.75s
+        //AutoAprilTag(m_limelight, m_drive, m_shooter).ToPtr(),
+        AutoSubAim(m_shooter).ToPtr(),
+        frc2::cmd::Sequence(
+          frc2::WaitCommand(0.75_s).ToPtr(), //can change if need
+          AutoShootCommand(m_shooterWheels, m_intake).ToPtr()
+        )
+      ),
+      frc2::cmd::Parallel(
+        FollowWaypoints(m_drive, m_limelight, redClose4Waypoint1, redClose4PointSpeed1, redClose4CruiseSpeed1, false).ToPtr(),
+        IntakeCmd(m_intake).ToPtr()
+      ),
+      frc2::cmd::Race( //aim shooter for 0.75s
+        AutoAprilTag(m_limelight, m_drive, m_shooter).ToPtr(),
+        frc2::cmd::Sequence(
+          frc2::WaitCommand(0.75_s).ToPtr(), //can change if need
+          AutoShootCommand(m_shooterWheels, m_intake).ToPtr()
+        )
+      ),
+      frc2::cmd::Parallel(
+        FollowWaypoints(m_drive, m_limelight, redClose4Waypoint2, redClose4PointSpeed2, redClose4CruiseSpeed2, false).ToPtr(),
+        IntakeCmd(m_intake).ToPtr()
+      ),
+      frc2::cmd::Race( //aim shooter for 0.75s
+        AutoAprilTag(m_limelight, m_drive, m_shooter).ToPtr(),
+        frc2::cmd::Sequence(
+          frc2::WaitCommand(0.75_s).ToPtr(), //can change if need
+          AutoShootCommand(m_shooterWheels, m_intake).ToPtr()
+        )
+      ),
+      frc2::cmd::Parallel(
+        FollowWaypoints(m_drive, m_limelight, redClose4Waypoint3, redClose4PointSpeed3, redClose4CruiseSpeed3, false).ToPtr(),
+        IntakeCmd(m_intake).ToPtr()
+      ),
+      frc2::cmd::Race( //aim shooter for 0.75s
+        AutoAprilTag(m_limelight, m_drive, m_shooter).ToPtr(),
+        frc2::cmd::Sequence(
+          frc2::WaitCommand(0.75_s).ToPtr(), //can change if need
+          AutoShootCommand(m_shooterWheels, m_intake).ToPtr()
+        )
+      ),
+      frc2::cmd::RunOnce(
+        [this]
+        {
+          m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
+        },
+        {&m_drive}
+      )
     );
   }
   else if(chosenAuto == "FarSideMid")
@@ -610,14 +668,14 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand()
         AutoAprilTag(m_limelight, m_drive, m_shooter).ToPtr(),
         frc2::WaitCommand(1.25_s).ToPtr() //can change if need
       ),
-      AutoShootCommand(m_shooterWheels, m_intake).ToPtr()
-      // frc2::cmd::RunOnce(
-      //   [this]
-      //   {
-      //     m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
-      //   },
-      //   {&m_drive}
-      // )
+      AutoShootCommand(m_shooterWheels, m_intake).ToPtr(),
+      frc2::cmd::RunOnce(
+        [this]
+        {
+          m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
+        },
+        {&m_drive}
+      )
     );
   }
   else
@@ -634,4 +692,8 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand()
 void RobotContainer::ZeroHeading()
 {
   m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
+}
+
+void RobotContainer::ShooterOff(){
+  m_shooterWheels.StopShooter();
 }

--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -316,6 +316,7 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand()
     m_drive.ResetOdometry(B_2Waypoints[0]);
     return frc2::cmd::Sequence( //the whole auto path!
       frc2::WaitCommand(0.1_s).ToPtr(),  //This is neccesary because the reset odometry will not actually reset until after a very small amount of time. 
+      AutoShooterWarmupCmd(m_shooterWheels).ToPtr(),
       frc2::cmd::Race( //aim shooter for 0.75s
         AutoAprilTag(m_limelight, m_drive, m_shooter).ToPtr(),
         frc2::WaitCommand(1.5_s).ToPtr() //can change if need
@@ -329,14 +330,14 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand()
         AutoAprilTag(m_limelight, m_drive, m_shooter).ToPtr(),
         frc2::WaitCommand(2_s).ToPtr()
       ),
-      AutoShootCommand(m_shooterWheels, m_intake).ToPtr(),
-      frc2::cmd::RunOnce(
-        [this]
-        {
-          m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
-        },
-        {&m_drive}
-      )
+      AutoShootCommand(m_shooterWheels, m_intake).ToPtr()
+      // frc2::cmd::RunOnce(
+      //   [this]
+      //   {
+      //     m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
+      //   },
+      //   {&m_drive}
+      // )
     );
   }
   //JustShoot ------------------------------------------------------------------------------------------------------------------------------------------------
@@ -345,18 +346,19 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand()
     m_drive.ResetOdometry({0_m, 0_m, -120_deg});
     return frc2::cmd::Sequence( //the whole auto path!
       frc2::WaitCommand(0.1_s).ToPtr(),  //This is neccesary because the reset odometry will not actually reset until after a very small amount of time. 
+      AutoShooterWarmupCmd(m_shooterWheels).ToPtr(),
       frc2::cmd::Race( //aim shooter for 0.75s
         AutoAprilTag(m_limelight, m_drive, m_shooter).ToPtr(),
         frc2::WaitCommand(1.5_s).ToPtr() //can change if need
       ),
-      AutoShootCommand(m_shooterWheels, m_intake).ToPtr(),
-      frc2::cmd::RunOnce(
-        [this]
-        {
-          m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
-        },
-        {&m_drive}
-      )
+      AutoShootCommand(m_shooterWheels, m_intake).ToPtr()
+      // frc2::cmd::RunOnce(
+      //   [this]
+      //   {
+      //     m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
+      //   },
+      //   {&m_drive}
+      // )
     );
   }
   else if(chosenAuto == "JustShootCenter")
@@ -364,18 +366,19 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand()
     m_drive.ResetOdometry({0_m, 0_m, 180_deg});
     return frc2::cmd::Sequence( //the whole auto path!
       frc2::WaitCommand(0.1_s).ToPtr(),  //This is neccesary because the reset odometry will not actually reset until after a very small amount of time. 
+      AutoShooterWarmupCmd(m_shooterWheels).ToPtr(),
       frc2::cmd::Race( //aim shooter for 0.75s
         AutoAprilTag(m_limelight, m_drive, m_shooter).ToPtr(),
         frc2::WaitCommand(1.5_s).ToPtr() //can change if need
       ),
-      AutoShootCommand(m_shooterWheels, m_intake).ToPtr(),
-      frc2::cmd::RunOnce(
-        [this]
-        {
-          m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
-        },
-        {&m_drive}
-      )
+      AutoShootCommand(m_shooterWheels, m_intake).ToPtr()
+      // frc2::cmd::RunOnce(
+      //   [this]
+      //   {
+      //     m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
+      //   },
+      //   {&m_drive}
+      // )
     );
   }
   else if(chosenAuto == "JustShootRight")
@@ -383,18 +386,19 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand()
     m_drive.ResetOdometry({0_m, 0_m, 120_deg});
     return frc2::cmd::Sequence( //the whole auto path!
       frc2::WaitCommand(0.1_s).ToPtr(),  //This is neccesary because the reset odometry will not actually reset until after a very small amount of time. 
+      AutoShooterWarmupCmd(m_shooterWheels).ToPtr(),
       frc2::cmd::Race( //aim shooter for 0.75s
         AutoAprilTag(m_limelight, m_drive, m_shooter).ToPtr(),
         frc2::WaitCommand(1.5_s).ToPtr() //can change if need
       ),
-      AutoShootCommand(m_shooterWheels, m_intake).ToPtr(),
-      frc2::cmd::RunOnce(
-        [this]
-        {
-          m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
-        },
-        {&m_drive}
-      )
+      AutoShootCommand(m_shooterWheels, m_intake).ToPtr()
+      // frc2::cmd::RunOnce(
+      //   [this]
+      //   {
+      //     m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
+      //   },
+      //   {&m_drive}
+      // )
     );
   }
   //Shoot then backup -------------------------------------------------------------------------------------------------------------------------------
@@ -403,25 +407,20 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand()
     m_drive.ResetOdometry(sideBackupWaypointsLeft[0]);
     return frc2::cmd::Sequence( //the whole auto path!
       frc2::WaitCommand(0.1_s).ToPtr(),  //This is neccesary because the reset odometry will not actually reset until after a very small amount of time. 
-      frc2::cmd::RunOnce(
-        [this]
-          {
-            m_shooter.zeroIntergralVal();
-          }
-      ),
+      AutoShooterWarmupCmd(m_shooterWheels).ToPtr(),
       frc2::cmd::Race( //aim shooter for 0.75s
         AutoAprilTag(m_limelight, m_drive, m_shooter).ToPtr(),
         frc2::WaitCommand(1.5_s).ToPtr() //can change if need
       ),
       AutoShootCommand(m_shooterWheels, m_intake).ToPtr(),
-      FollowWaypoints(m_drive, m_limelight, sideBackupWaypointsLeft, sideBackupPointSpeedLeft, sideBackupCruiseSpeedLeft, false).ToPtr(),
-      frc2::cmd::RunOnce(
-        [this]
-        {
-          m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
-        },
-        {&m_drive}
-      )
+      FollowWaypoints(m_drive, m_limelight, sideBackupWaypointsLeft, sideBackupPointSpeedLeft, sideBackupCruiseSpeedLeft, false).ToPtr()
+      // frc2::cmd::RunOnce(
+      //   [this]
+      //   {
+      //     m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
+      //   },
+      //   {&m_drive}
+      // )
     );
   }
   else if(chosenAuto == "ShootTobackupRight")
@@ -430,25 +429,20 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand()
     m_drive.ResetOdometry(sideBackupWaypointsRight[0]);
     return frc2::cmd::Sequence( //the whole auto path!
       frc2::WaitCommand(0.1_s).ToPtr(),  //This is neccesary because the reset odometry will not actually reset until after a very small amount of time. 
-      frc2::cmd::RunOnce(
-        [this]
-          {
-            m_shooter.zeroIntergralVal();
-          }
-      ),
+      AutoShooterWarmupCmd(m_shooterWheels).ToPtr(),
       frc2::cmd::Race( //aim shooter for 0.75s
         AutoAprilTag(m_limelight, m_drive, m_shooter).ToPtr(),
         frc2::WaitCommand(1.5_s).ToPtr() //can change if need
       ),
       AutoShootCommand(m_shooterWheels, m_intake).ToPtr(),
-      FollowWaypoints(m_drive, m_limelight, sideBackupWaypointsRight, sideBackupPointSpeedRight, sideBackupCruiseSpeedRight, false).ToPtr(),
-      frc2::cmd::RunOnce(
-        [this]
-        {
-          m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
-        },
-        {&m_drive}
-      )
+      FollowWaypoints(m_drive, m_limelight, sideBackupWaypointsRight, sideBackupPointSpeedRight, sideBackupCruiseSpeedRight, false).ToPtr()
+      // frc2::cmd::RunOnce(
+      //   [this]
+      //   {
+      //     m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
+      //   },
+      //   {&m_drive}
+      // )
     );
   }
   else if(chosenAuto == "B_1")
@@ -456,6 +450,7 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand()
     m_drive.ResetOdometry(B_1Waypoints[0]);
       return frc2::cmd::Sequence( //the whole auto path!
       frc2::WaitCommand(0.1_s).ToPtr(),  //This is neccesary because the reset odometry will not actually reset until after a very small amount of time.
+      AutoShooterWarmupCmd(m_shooterWheels).ToPtr(),
       frc2::cmd::Parallel( 
         frc2::cmd::Race( //aim shooter for 0.75s
           AutoAprilTag(m_limelight, m_drive, m_shooter).ToPtr(),
@@ -473,14 +468,14 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand()
           frc2::WaitCommand(1.5_s).ToPtr() //can change if need
         )
       ),
-      AutoShootCommand(m_shooterWheels, m_intake).ToPtr(),
-      frc2::cmd::RunOnce(
-        [this]
-        {
-          m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
-        },
-        {&m_drive}
-      )
+      AutoShootCommand(m_shooterWheels, m_intake).ToPtr()
+      // frc2::cmd::RunOnce(
+      //   [this]
+      //   {
+      //     m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
+      //   },
+      //   {&m_drive}
+      // )
     );
   }
   else if(chosenAuto == "B_3_6")
@@ -488,6 +483,7 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand()
     m_drive.ResetOdometry(B_3_6Waypoints1[0]);
     return frc2::cmd::Sequence(
       frc2::WaitCommand(0.1_s).ToPtr(),  //This is neccesary because the reset odometry will not actually reset until after a very small amount of time. 
+      AutoShooterWarmupCmd(m_shooterWheels).ToPtr(),
       frc2::cmd::Race( //aim shooter for 0.75s
         AutoAprilTag(m_limelight, m_drive, m_shooter).ToPtr(),
         frc2::WaitCommand(0.5_s).ToPtr() //can change if need
@@ -518,14 +514,14 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand()
           frc2::WaitCommand(0.5_s).ToPtr() //can change if need
         )
       ),
-      AutoShootCommand(m_shooterWheels, m_intake).ToPtr(),
-      frc2::cmd::RunOnce(
-        [this]
-        {
-          m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
-        },
-        {&m_drive}
-      )
+      AutoShootCommand(m_shooterWheels, m_intake).ToPtr()
+      // frc2::cmd::RunOnce(
+      //   [this]
+      //   {
+      //     m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
+      //   },
+      //   {&m_drive}
+      // )
     );  
   }
   else if(chosenAuto == "Close4")
@@ -533,51 +529,54 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand()
     m_drive.ResetOdometry(close4Waypoint1[0]);
     return frc2::cmd::Sequence( //the whole auto path!
       frc2::WaitCommand(0.1_s).ToPtr(),  //This is neccesary because the reset odometry will not actually reset until after a very small amount of time. 
-      frc2::cmd::RunOnce(
-        [this]
-          {
-            m_shooter.zeroIntergralVal();
-          }
-      ),
+      AutoShooterWarmupCmd(m_shooterWheels).ToPtr(),
       frc2::cmd::Race( //aim shooter for 0.75s
         AutoAprilTag(m_limelight, m_drive, m_shooter).ToPtr(),
-        frc2::WaitCommand(0.5_s).ToPtr() //can change if need
+        frc2::cmd::Sequence(
+          frc2::WaitCommand(0.5_s).ToPtr(), //can change if need
+          AutoShootCommand(m_shooterWheels, m_intake).ToPtr()
+        )
       ),
-      AutoShootCommand(m_shooterWheels, m_intake).ToPtr(),
       frc2::cmd::Parallel(
         FollowWaypoints(m_drive, m_limelight, close4Waypoint1, close4PointSpeed1, close4CruiseSpeed1, false).ToPtr(),
         IntakeCmd(m_intake).ToPtr()
       ),
       frc2::cmd::Race( //aim shooter for 0.75s
         AutoAprilTag(m_limelight, m_drive, m_shooter).ToPtr(),
-        frc2::WaitCommand(1.25_s).ToPtr() //can change if need
+        frc2::cmd::Sequence(
+          frc2::WaitCommand(0.75_s).ToPtr(), //can change if need
+          AutoShootCommand(m_shooterWheels, m_intake).ToPtr()
+        )
       ),
-      AutoShootCommand(m_shooterWheels, m_intake).ToPtr(),
       frc2::cmd::Parallel(
         FollowWaypoints(m_drive, m_limelight, close4Waypoint2, close4PointSpeed2, close4CruiseSpeed2, false).ToPtr(),
         IntakeCmd(m_intake).ToPtr()
       ),
       frc2::cmd::Race( //aim shooter for 0.75s
         AutoAprilTag(m_limelight, m_drive, m_shooter).ToPtr(),
-        frc2::WaitCommand(1.25_s).ToPtr() //can change if need
+        frc2::cmd::Sequence(
+          frc2::WaitCommand(0.75_s).ToPtr(), //can change if need
+          AutoShootCommand(m_shooterWheels, m_intake).ToPtr()
+        )
       ),
-      AutoShootCommand(m_shooterWheels, m_intake).ToPtr(),
       frc2::cmd::Parallel(
-        FollowWaypoints(m_drive, m_limelight, close4Waypoint3, close4PointSpeed3, close4CruiseSpeed3, false).ToPtr(),
+        FollowWaypoints(m_drive, m_limelight, close4Waypoint3, close4PointSpeed3, close4CruiseSpeed3, true).ToPtr(),
         IntakeCmd(m_intake).ToPtr()
       ),
       frc2::cmd::Race( //aim shooter for 0.75s
         AutoAprilTag(m_limelight, m_drive, m_shooter).ToPtr(),
-        frc2::WaitCommand(1.25_s).ToPtr() //can change if need
-      ),
-      AutoShootCommand(m_shooterWheels, m_intake).ToPtr(),
-      frc2::cmd::RunOnce(
-        [this]
-        {
-          m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
-        },
-        {&m_drive}
+        frc2::cmd::Sequence(
+          frc2::WaitCommand(0.75_s).ToPtr(), //can change if need
+          AutoShootCommand(m_shooterWheels, m_intake).ToPtr()
+        )
       )
+      // frc2::cmd::RunOnce(
+      //   [this]
+      //   {
+      //     m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
+      //   },
+      //   {&m_drive}
+      // )
     );
   }
   else if(chosenAuto == "FarSideMid")
@@ -585,12 +584,7 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand()
     m_drive.ResetOdometry(FarSideMid1[0]);
     return frc2::cmd::Sequence( //the whole auto path!
       frc2::WaitCommand(0.1_s).ToPtr(),  //This is neccesary because the reset odometry will not actually reset until after a very small amount of time. 
-      frc2::cmd::RunOnce(
-        [this]
-          {
-            m_shooter.zeroIntergralVal();
-          }
-      ),
+      AutoShooterWarmupCmd(m_shooterWheels).ToPtr(),
       FollowWaypoints(m_drive, m_limelight, FarSideMid1, FarSideMidPoint1, FarSideMidCruise1, false).ToPtr(),
       frc2::cmd::Race( //aim shooter for 0.75s
         AutoAprilTag(m_limelight, m_drive, m_shooter).ToPtr(),
@@ -616,14 +610,14 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand()
         AutoAprilTag(m_limelight, m_drive, m_shooter).ToPtr(),
         frc2::WaitCommand(1.25_s).ToPtr() //can change if need
       ),
-      AutoShootCommand(m_shooterWheels, m_intake).ToPtr(),
-      frc2::cmd::RunOnce(
-        [this]
-        {
-          m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
-        },
-        {&m_drive}
-      )
+      AutoShootCommand(m_shooterWheels, m_intake).ToPtr()
+      // frc2::cmd::RunOnce(
+      //   [this]
+      //   {
+      //     m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
+      //   },
+      //   {&m_drive}
+      // )
     );
   }
   else
@@ -635,4 +629,9 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand()
       frc2::WaitCommand(0.1_s).ToPtr()
     );
   }
+}
+
+void RobotContainer::ZeroHeading()
+{
+  m_drive.ZeroHeading(m_drive.GetPose().Rotation().Degrees());
 }

--- a/src/main/cpp/RobotContainer.cpp
+++ b/src/main/cpp/RobotContainer.cpp
@@ -560,7 +560,7 @@ frc2::CommandPtr RobotContainer::GetAutonomousCommand()
         )
       ),
       frc2::cmd::Parallel(
-        FollowWaypoints(m_drive, m_limelight, close4Waypoint3, close4PointSpeed3, close4CruiseSpeed3, true).ToPtr(),
+        FollowWaypoints(m_drive, m_limelight, close4Waypoint3, close4PointSpeed3, close4CruiseSpeed3, false).ToPtr(),
         IntakeCmd(m_intake).ToPtr()
       ),
       frc2::cmd::Race( //aim shooter for 0.75s

--- a/src/main/cpp/commands/AmpCommand.cpp
+++ b/src/main/cpp/commands/AmpCommand.cpp
@@ -20,8 +20,6 @@ void AmpCommand::Initialize()
 // Called repeatedly when this Command is scheduled to run
 void AmpCommand::Execute()
 {
-  frc::SmartDashboard::PutString("armAmp", "");
-
   if(m_arm->GetOffSetEncoderValueLower() > 100)
   {
     m_arm->RunArmWheels(-1);

--- a/src/main/cpp/commands/AutoAprilTag.cpp
+++ b/src/main/cpp/commands/AutoAprilTag.cpp
@@ -46,6 +46,7 @@ void AutoAprilTag::Execute()
 void AutoAprilTag::End(bool interrupted)
 {
   m_drive->Drive(0_rad_per_s, false, false);
+  m_shooter->setRestingActuatorPosition();
 }
 
 // Returns true when the command should end.

--- a/src/main/cpp/commands/AutoShootCommand.cpp
+++ b/src/main/cpp/commands/AutoShootCommand.cpp
@@ -25,15 +25,12 @@ void AutoShootCommand::Initialize()
 // Called repeatedly when this Command is scheduled to run
 void AutoShootCommand::Execute() 
 {
-  if(time <= 60) //todo change values to be most efficient/effective
-  {
-    ShooterWarmup();
-  }
-  else if(60 <= time && time <= 100)
+
+  if(time <= 40)
   {
     shoot();
   }
-  else if(time >= 100)
+  else if(time >= 40)
   {
     stopShoot();
     finished = true;
@@ -44,7 +41,7 @@ void AutoShootCommand::Execute()
 
 void AutoShootCommand::ShooterWarmup()
 {
-  m_shooterWheel->SetShooter(0.75, 0.75);
+  m_shooterWheel->PIDShoot();
 }
 
 void AutoShootCommand::shoot()
@@ -58,7 +55,6 @@ void AutoShootCommand::stopShoot()
 {
   m_intake->StopIntake();
   m_intake->StopMagazine();
-  m_shooterWheel->StopShooter();
 }
 
 // Called once the command ends or is interrupted.

--- a/src/main/cpp/commands/AutoShootCommand.cpp
+++ b/src/main/cpp/commands/AutoShootCommand.cpp
@@ -48,7 +48,7 @@ void AutoShootCommand::shoot()
 {
   m_intake->RunIntake(1);
   m_intake->RunMagazine(1);
-  m_intake->DirectionNote(1);
+  m_intake->DirectionNote(1); // why run this?
 }
 
 void AutoShootCommand::stopShoot()

--- a/src/main/cpp/commands/AutoShooterWarmupCmd.cpp
+++ b/src/main/cpp/commands/AutoShooterWarmupCmd.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "commands/AutoShooterWarmupCmd.h"
+
+AutoShooterWarmupCmd::AutoShooterWarmupCmd(ShooterWheelsSubsystem &shooterWheel)
+{
+  m_shooterWheel = &shooterWheel;
+  AddRequirements({m_shooterWheel});
+}
+
+// Called when the command is initially scheduled.
+void AutoShooterWarmupCmd::Initialize()
+{
+  m_shooterWheel->PIDShoot();
+}
+
+// Called repeatedly when this Command is scheduled to run
+void AutoShooterWarmupCmd::Execute()
+{
+  //do nothing
+}
+
+// Called once the command ends or is interrupted.
+void AutoShooterWarmupCmd::End(bool interrupted){}
+
+// Returns true when the command should end.
+bool AutoShooterWarmupCmd::IsFinished() {
+  return true;
+}

--- a/src/main/cpp/commands/AutoSubAim.cpp
+++ b/src/main/cpp/commands/AutoSubAim.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#include "commands/AutoSubAim.h"
+
+AutoSubAim::AutoSubAim() {}
+
+AutoSubAim::AutoSubAim(ShooterSubsystem &shooter) {
+  m_shooter = &shooter;
+  AddRequirements({m_shooter});
+}
+
+// Called when the command is initially scheduled.
+void AutoSubAim::Initialize() {
+  m_shooter->SetActuator(ShooterConstants::SubwooferAngle); 
+}
+
+// Called repeatedly when this Command is scheduled to run
+void AutoSubAim::Execute() {
+  if(time >= 60)
+  {
+    timeIsUp = true;
+  }
+  else
+  {
+    time++;
+  }
+}
+
+// Called once the command ends or is interrupted.
+void AutoSubAim::End(bool interrupted) {
+  m_shooter->setRestingActuatorPosition();
+}
+
+// Returns true when the command should end.
+bool AutoSubAim::IsFinished() {
+  return timeIsUp;
+}

--- a/src/main/cpp/subsystems/DriveSubsystem.cpp
+++ b/src/main/cpp/subsystems/DriveSubsystem.cpp
@@ -61,6 +61,7 @@ void DriveSubsystem::Periodic(){
 
   frc::SmartDashboard::PutNumber("NavX temp", m_gyro.GetTempC());
   frc::SmartDashboard::PutNumber("OrientationOffset", orientationOffset.Degrees().value());
+  //frc::SmartDashboard::PutNumber("heading", GetHeading());
 
   m_odometry.Update(
     frc::Rotation2d(frc::Rotation2d(m_gyro.GetRotation2d().Radians())),
@@ -212,7 +213,7 @@ units::degree_t DriveSubsystem::GetHeading()
 
 void DriveSubsystem::ZeroHeading(frc::Rotation2d startRot)
 {
-  orientationOffset = 2 * (startRot.Degrees());
+  orientationOffset = (startRot.Degrees());
   m_gyro.Reset();
 }
 

--- a/src/main/cpp/subsystems/ShooterWheelsSubsystem.cpp
+++ b/src/main/cpp/subsystems/ShooterWheelsSubsystem.cpp
@@ -6,8 +6,8 @@
 
 ShooterWheelsSubsystem::ShooterWheelsSubsystem()
 {
-    TopShooterPID.SetP(0.000015);
-    BottomShooterPID.SetP(0.000015);
+    TopShooterPID.SetP(0.000005);
+    BottomShooterPID.SetP(0.000005);
 
     TopShooterPID.SetI(0.0000003);
     BottomShooterPID.SetI(0.0000003);

--- a/src/main/include/Constants.h
+++ b/src/main/include/Constants.h
@@ -130,7 +130,7 @@ namespace ShooterConstants
     constexpr double RestingAngle = 20;//32; //also the low angle. TODO will change for updated offfset
 
     constexpr double SubwooferAngle = 52.1;   // temp value, please test and find out
-    constexpr double StageAngle = 53.61;       // temp value, please test and find out
+    constexpr double StageAngle = 38.18;//53.61;       // temp value, please test and find out
     constexpr double AmpAngle = 0;          // TODO find angle value
     constexpr double ShooterMaxSoftLimit = 80;
     constexpr double ShooterMinSoftLimit = 20;

--- a/src/main/include/Constants.h
+++ b/src/main/include/Constants.h
@@ -129,8 +129,8 @@ namespace ShooterConstants
     constexpr double AngleThreshold = 0.027;
     constexpr double RestingAngle = 20;//32; //also the low angle. TODO will change for updated offfset
 
-    constexpr double SubwooferAngle = 60;   // temp value, please test and find out
-    constexpr double StageAngle = 40;       // temp value, please test and find out
+    constexpr double SubwooferAngle = 52.1;   // temp value, please test and find out
+    constexpr double StageAngle = 53.61;       // temp value, please test and find out
     constexpr double AmpAngle = 0;          // TODO find angle value
     constexpr double ShooterMaxSoftLimit = 80;
     constexpr double ShooterMinSoftLimit = 20;

--- a/src/main/include/RobotContainer.h
+++ b/src/main/include/RobotContainer.h
@@ -51,6 +51,7 @@
 #include "commands/AmpShooter.h"
 #include "commands/AmpLineup.h"
 #include "commands/AutoShooterWarmupCmd.h"
+#include "commands/AutoSubAim.h"
 
 /**
  * This class is where the bulk of the robot should be declared.  Since
@@ -69,6 +70,7 @@ class RobotContainer
     float DeadzoneCubed(float x);
     void ConfigureButtonBindings();
     void ZeroHeading();
+    void ShooterOff();
 
   private:
     //replace with frc::Joystick if using a joystick instead of an xbox controller
@@ -314,13 +316,14 @@ class RobotContainer
     std::vector<frc::Pose2d> close4Waypoint2
     {
       frc::Pose2d(2.65_m, 5.55_m, 180_deg),
-      frc::Pose2d(2.2_m, 6.8_m, 180_deg),
-      frc::Pose2d(2.65_m, 7_m, 180_deg)
+      //frc::Pose2d(2.2_m, 6.8_m, 180_deg),
+      frc::Pose2d(2.65_m, 7_m, 230_deg),
+      //frc::Pose2d(2.65_m, 7_m, 230_deg)
     };
 
     std::vector<frc::Pose2d> close4Waypoint3
     {
-      frc::Pose2d(2.65_m, 7_m, 180_deg),
+      frc::Pose2d(2.65_m, 7_m, 230_deg),
       frc::Pose2d(2.2_m, 4.3_m, 180_deg),
       frc::Pose2d(2.6_m, 4.1_m, 180_deg),
       frc::Pose2d(2.35_m, 4.1_m, 130_deg)
@@ -328,45 +331,110 @@ class RobotContainer
 
     std::vector<units::meters_per_second_t> close4PointSpeed1
     {
-      0_mps,
+      0.5_mps,
       2_mps
     };
 
     std::vector<units::meters_per_second_t> close4PointSpeed2
     {
-      1_mps,
-      2_mps,
-      1.5_mps
+      1.5_mps,
+      1.5_mps,
+      //0_mps
     };
 
     std::vector<units::meters_per_second_t> close4PointSpeed3
     {
       1_mps,
-      1.5_mps,
-      1.5_mps,
+      2_mps,
+      1_mps,
       0_mps
     };
 
     std::vector<units::meters_per_second_t> close4CruiseSpeed1
     {
-      2_mps,
+      2.5_mps,
       1.5_mps
     };
 
     std::vector<units::meters_per_second_t> close4CruiseSpeed2
     {
-      1_mps,
-      2_mps,
-      1.5_mps
+      1.5_mps,
+      1.5_mps,
+      //0_mps
     };
 
     std::vector<units::meters_per_second_t> close4CruiseSpeed3
     {
+      1.5_mps,
+      2_mps,
+      1_mps,
+      0.5_mps
+    };
+  
+  std::vector<frc::Pose2d> redClose4Waypoint1
+    {
+      frc::Pose2d(14.7_m, 5.55_m, 180_deg),
+      frc::Pose2d(13.35_m, 5.55_m, 180_deg)
+    };
+
+    std::vector<frc::Pose2d> redClose4Waypoint2
+    {
+      frc::Pose2d(13.35_m, 5.55_m, 180_deg),
+      //frc::Pose2d(2.2_m, 6.8_m, 180_deg),
+      frc::Pose2d(13.35_m, 7_m, 230_deg),
+      //frc::Pose2d(2.65_m, 7_m, 230_deg)
+    };
+
+    std::vector<frc::Pose2d> redClose4Waypoint3
+    {
+      frc::Pose2d(13.35_m, 7_m, 230_deg),
+      frc::Pose2d(13.8_m, 4.3_m, 180_deg),
+      frc::Pose2d(13.4_m, 4.1_m, 180_deg),
+      frc::Pose2d(13.65_m, 4.1_m, 130_deg)
+    };
+
+    std::vector<units::meters_per_second_t> redClose4PointSpeed1
+    {
+      0.5_mps,
+      2_mps
+    };
+
+    std::vector<units::meters_per_second_t> redClose4PointSpeed2
+    {
+      1.5_mps,
+      1.5_mps,
+      //0_mps
+    };
+
+    std::vector<units::meters_per_second_t> redClose4PointSpeed3
+    {
       1_mps,
       2_mps,
       1_mps,
-      1_mps
+      0_mps
     };
+
+    std::vector<units::meters_per_second_t> redClose4CruiseSpeed1
+    {
+      2.5_mps,
+      1.5_mps
+    };
+
+    std::vector<units::meters_per_second_t> redClose4CruiseSpeed2
+    {
+      1.5_mps,
+      1.5_mps,
+      //0_mps
+    };
+
+    std::vector<units::meters_per_second_t> redClose4CruiseSpeed3
+    {
+      1.5_mps,
+      2_mps,
+      1_mps,
+      0.5_mps
+    };
+
 
     std::vector<frc::Pose2d> FarSideMid1
     {

--- a/src/main/include/RobotContainer.h
+++ b/src/main/include/RobotContainer.h
@@ -323,7 +323,7 @@ class RobotContainer
       frc::Pose2d(2.65_m, 7_m, 180_deg),
       frc::Pose2d(2.2_m, 4.3_m, 180_deg),
       frc::Pose2d(2.6_m, 4.1_m, 180_deg),
-      frc::Pose2d(2.35_m, 4.1_m, -130_deg)
+      frc::Pose2d(2.35_m, 4.1_m, 130_deg)
     };
 
     std::vector<units::meters_per_second_t> close4PointSpeed1

--- a/src/main/include/RobotContainer.h
+++ b/src/main/include/RobotContainer.h
@@ -88,10 +88,20 @@ class RobotContainer
 
     frc::SendableChooser<std::string> m_chooser;
     std::string chosenAuto;
-
     std::vector<AutoPaths::AutoPath> path;
 
-    //Blue auto Paths
+    //CURRENT PATHS
+    //RED - 4 NOTE
+    //RED - SOURCE
+    //RED - AMP
+
+    //BLUE - 4 NOTE
+    //BLUE - SOURCE
+    //BLUE - AMP
+
+
+    /*
+    //Blue 1
     std::vector<frc::Pose2d>  B_1Waypoints
     {
       frc::Pose2d(0.7_m, 6.65_m, frc::Rotation2d(120_deg)), 
@@ -130,6 +140,10 @@ class RobotContainer
     std::string B_1EndCommand = "Shoot";
     std::string B_12EndCommand = "NoteFollow"; //temp string to force a state when testing
 
+    */
+
+   /*BLUE - 2
+
     std::vector<frc::Pose2d>  B_2Waypoints
     {
       frc::Pose2d(1.45_m, 5.55_m, frc::Rotation2d(180_deg)),
@@ -147,6 +161,10 @@ class RobotContainer
       1_mps,
       1.5_mps
     };
+
+    */
+
+   /* SIDE BACKUP
 
     std::vector<frc::Pose2d>  sideBackupWaypointsLeft
     {
@@ -184,6 +202,10 @@ class RobotContainer
       1.5_mps
     };
 
+    */
+
+
+    /* BLUE - 3
     std::vector<frc::Pose2d>  B_3Waypoints
     {
       frc::Pose2d(1.45_m, 4.1_m, frc::Rotation2d(180_deg)),
@@ -202,6 +224,9 @@ class RobotContainer
       1.5_mps
     };
 
+    */
+
+    /* BLUE - 1 2 3
     std::vector<frc::Pose2d>  B_1_2_3Waypoints
     {
       frc::Pose2d(1.45_m, 7.0_m, frc::Rotation2d(180_deg)),
@@ -232,7 +257,9 @@ class RobotContainer
       2_mps
     };
 
+    */
 
+    /* BLUE - 3 6
     std::vector<frc::Pose2d> B_3_6Waypoints1
     {
       frc::Pose2d(0.7_m, 4.4_m, frc::Rotation2d(120_deg)), //if this works needs to be changed on all B_3_.... statements.
@@ -307,6 +334,30 @@ class RobotContainer
       1.5_mps
     };
 
+    */
+
+   //THESE ARE THE TEST POINTS FOR JUSTSHOOTCENTER OUR TEST PATH
+   std::vector<frc::Pose2d> close4Waypoint1JustShootCenter
+    {
+      frc::Pose2d(1.3_m, 5.55_m, 180_deg),
+      frc::Pose2d(2.65_m, 5.55_m, 180_deg)
+    };
+
+    std::vector<units::meters_per_second_t> close4PointSpeed1JustShootCenter
+    {
+      0.5_mps,
+      2_mps
+    };
+
+    std::vector<units::meters_per_second_t> close4CruiseSpeed1JustShootCenter
+    {
+      2.5_mps,
+      1.5_mps
+    };
+    //END TEST
+    
+
+    // BLUE FRONT 4 NOTE
     std::vector<frc::Pose2d> close4Waypoint1
     {
       frc::Pose2d(1.3_m, 5.55_m, 180_deg),
@@ -316,9 +367,7 @@ class RobotContainer
     std::vector<frc::Pose2d> close4Waypoint2
     {
       frc::Pose2d(2.65_m, 5.55_m, 180_deg),
-      //frc::Pose2d(2.2_m, 6.8_m, 180_deg),
-      frc::Pose2d(2.65_m, 7_m, 230_deg),
-      //frc::Pose2d(2.65_m, 7_m, 230_deg)
+      frc::Pose2d(2.65_m, 7_m, 230_deg)
     };
 
     std::vector<frc::Pose2d> close4Waypoint3
@@ -338,8 +387,7 @@ class RobotContainer
     std::vector<units::meters_per_second_t> close4PointSpeed2
     {
       1.5_mps,
-      1.5_mps,
-      //0_mps
+      1.5_mps
     };
 
     std::vector<units::meters_per_second_t> close4PointSpeed3
@@ -359,8 +407,7 @@ class RobotContainer
     std::vector<units::meters_per_second_t> close4CruiseSpeed2
     {
       1.5_mps,
-      1.5_mps,
-      //0_mps
+      1.5_mps
     };
 
     std::vector<units::meters_per_second_t> close4CruiseSpeed3
@@ -370,8 +417,13 @@ class RobotContainer
       1_mps,
       0.5_mps
     };
-  
-  std::vector<frc::Pose2d> redClose4Waypoint1
+
+
+
+
+
+    // RED FRONT 4 NOTE - TODO: RED SIDE NEEDS TO BE TESTED
+    std::vector<frc::Pose2d> redClose4Waypoint1
     {
       frc::Pose2d(14.7_m, 5.55_m, 180_deg),
       frc::Pose2d(13.35_m, 5.55_m, 180_deg)
@@ -380,9 +432,7 @@ class RobotContainer
     std::vector<frc::Pose2d> redClose4Waypoint2
     {
       frc::Pose2d(13.35_m, 5.55_m, 180_deg),
-      //frc::Pose2d(2.2_m, 6.8_m, 180_deg),
-      frc::Pose2d(13.35_m, 7_m, 230_deg),
-      //frc::Pose2d(2.65_m, 7_m, 230_deg)
+      frc::Pose2d(13.35_m, 7_m, 230_deg)
     };
 
     std::vector<frc::Pose2d> redClose4Waypoint3
@@ -402,8 +452,7 @@ class RobotContainer
     std::vector<units::meters_per_second_t> redClose4PointSpeed2
     {
       1.5_mps,
-      1.5_mps,
-      //0_mps
+      1.5_mps
     };
 
     std::vector<units::meters_per_second_t> redClose4PointSpeed3
@@ -423,8 +472,7 @@ class RobotContainer
     std::vector<units::meters_per_second_t> redClose4CruiseSpeed2
     {
       1.5_mps,
-      1.5_mps,
-      //0_mps
+      1.5_mps
     };
 
     std::vector<units::meters_per_second_t> redClose4CruiseSpeed3
@@ -436,36 +484,47 @@ class RobotContainer
     };
 
 
+    //BLUE SOURCE 3 NOTE
+    //Start to first shooting spot
     std::vector<frc::Pose2d> FarSideMid1
     {
-      frc::Pose2d(0.45_m, 2.05_m, 180_deg),
-      frc::Pose2d(3.5_m, 2.05_m, 180_deg)
+      frc::Pose2d(0.45_m, 2.5_m, 180_deg),
+      frc::Pose2d(2.5_m, 2.5_m, 130_deg)
     };
 
+    //Post first shoot to midline pickup
     std::vector<frc::Pose2d> FarSideMid2
     {
-      frc::Pose2d(3.5_m, 2.05_m, 180_deg),
-      frc::Pose2d(8.15_m, 0.8_m, 180_deg)
+      frc::Pose2d(2.75_m, 2.5_m, 130_deg),
+      frc::Pose2d(8.25_m, 0.8_m, 160_deg)
     };
 
+    //Midline pickup to 2nd shooting spot
     std::vector<frc::Pose2d> FarSideMid3
     {
-      frc::Pose2d(8.15_m, 0.8_m, 180_deg),
-      frc::Pose2d(3.5_m, 2.05_m, 180_deg)
+      frc::Pose2d(8.05_m, 0.8_m, 160_deg),
+      frc::Pose2d(5.5_m, 1.8_m, 180_deg),
+      frc::Pose2d(4.0_m, 3.0_m, 130_deg)
     };
     
+    //Post 2nd shot around pillar to 3rd note pickup
     std::vector<frc::Pose2d> FarSideMid4
     {
-      frc::Pose2d(3.5_m, 2.05_m, 180_deg),
+      frc::Pose2d(3.9_m, 2.25_m, 130_deg),
       frc::Pose2d(5.5_m, 1.8_m, 180_deg),
-      frc::Pose2d(8.15_m, 2.45_m, 180_deg)
+      frc::Pose2d(8.25_m, 2.45_m, 200_deg)
     };
 
+    //3rd note pickup to 3rd not shooting spot
     std::vector<frc::Pose2d> FarSideMid5
     {
-      frc::Pose2d(8.15_m, 2.45_m, 180_deg),
-      frc::Pose2d(5.5_m, 1.8_m, 180_deg),
-      frc::Pose2d(3.5_m, 2.05_m, 180_deg)
+      frc::Pose2d(8.05_m, 2.45_m, 200_deg),
+      frc::Pose2d(6.0_m, 1.6_m, 180_deg),
+      frc::Pose2d(4.0_m, 3.0_m, 130_deg)
+
+      //Potential cut through middle stage for 3rd note.
+      //frc::Pose2d(5.6_m, 4.0_m, 160_deg),
+      //frc::Pose2d(4.0_m, 5.55_m, 200_deg)
     };
 
     std::vector<units::velocity::meters_per_second_t> FarSideMidPoint1
@@ -484,6 +543,7 @@ class RobotContainer
     std::vector<units::velocity::meters_per_second_t> FarSideMidPoint3
     {
       1_mps,
+      2_mps,
       0_mps
     };
 
@@ -502,6 +562,7 @@ class RobotContainer
       0_mps
     };
 
+
     std::vector<units::velocity::meters_per_second_t> FarSideMidCruise1
     {
       1_mps,
@@ -517,6 +578,7 @@ class RobotContainer
     std::vector<units::velocity::meters_per_second_t> FarSideMidCruise3
     {
       1_mps,
+      3_mps,
       3_mps
     };
     
@@ -528,6 +590,144 @@ class RobotContainer
     };
     
     std::vector<units::velocity::meters_per_second_t> FarSideMidCruise5
+    {
+      1_mps,
+      3_mps,
+      3_mps
+    };
+
+    /*********************************************************************************/
+    
+    //TODO: 
+    //RED SOURCE 3 NOTE POSE VALUES HAVE NOT BEEN SET
+    //IN FACT - THEY AREN'T EVEN CONSISTENT
+    //DO NOT RUN THIS UNDER ANY CIRCUMSTANCE
+    //WITHOUT FIRST INPUTTING THE CORRECT POSE WAYPOINT VALUES
+
+    /*********************************************************************************/
+
+    //RED SOURCE 3 NOTE
+    //Start to first shooting spot
+    std::vector<frc::Pose2d> redFarSideMid1
+    {
+      frc::Pose2d(0.45_m, 2.5_m, 180_deg),
+      frc::Pose2d(2.5_m, 2.5_m, 230_deg)
+      //frc::Pose2d(15.55_m, 2.5_m, 180_deg),
+      //frc::Pose2d(13.5_m, 2.5_m, 230_deg)
+    };
+
+    //Post first shoot to midline pickup
+    std::vector<frc::Pose2d> redFarSideMid2
+    {
+      frc::Pose2d(13.25_m, 2.5_m, 230_deg),
+      frc::Pose2d(7.75_m, 0.8_m, 200_deg)
+      //frc::Pose2d(13.25_m, 2.5_m, 230_deg),
+      //frc::Pose2d(7.75_m, 0.8_m, 200_deg)
+    };
+
+    //Midline pickup to 2nd shooting spot
+    std::vector<frc::Pose2d> redFarSideMid3
+    {
+      frc::Pose2d(7.95_m, 0.8_m, 200_deg),
+      frc::Pose2d(10.5_m, 1.8_m, 180_deg),
+      frc::Pose2d(12.0_m, 3.0_m, 230_deg)
+
+      //frc::Pose2d(7.95_m, 0.8_m, 200_deg),
+      //frc::Pose2d(10.5_m, 1.8_m, 180_deg),
+      //frc::Pose2d(12.0_m, 3.0_m, 230_deg)
+    };
+    
+    //Post 2nd shot around pillar to 3rd note pickup
+    std::vector<frc::Pose2d> redFarSideMid4
+    {
+      frc::Pose2d(12.1_m, 2.25_m, 230_deg),
+      frc::Pose2d(10.5_m, 1.8_m, 180_deg),
+      frc::Pose2d(7.75_m, 2.45_m, 160_deg)
+
+      //frc::Pose2d(12.1_m, 2.25_m, 230_deg),
+      //frc::Pose2d(10.5_m, 1.8_m, 180_deg),
+      //frc::Pose2d(7.75_m, 2.45_m, 160_deg)
+    };
+
+    //3rd note pickup to 3rd not shooting spot
+    std::vector<frc::Pose2d> redFarSideMid5
+    {
+      frc::Pose2d(7.95_m, 2.45_m, 160_deg),
+      frc::Pose2d(10.0_m, 1.6_m, 180_deg),
+      frc::Pose2d(12.0_m, 3.0_m, 230_deg)
+
+      //frc::Pose2d(7.95_m, 2.45_m, 160_deg),
+      //frc::Pose2d(10.0_m, 1.6_m, 180_deg),
+      //frc::Pose2d(12.0_m, 3.0_m, 230_deg)
+
+      //Potential cut through middle stage for 3rd note.
+      //frc::Pose2d(5.6_m, 4.0_m, 160_deg),
+      //frc::Pose2d(4.0_m, 5.55_m, 200_deg)
+    };
+
+    std::vector<units::velocity::meters_per_second_t> redFarSideMidPoint1
+    {
+      1_mps,
+      0_mps
+    };
+
+    std::vector<units::velocity::meters_per_second_t> redFarSideMidPoint2
+    {
+      1_mps,
+      0_mps
+    };
+
+    
+    std::vector<units::velocity::meters_per_second_t> redFarSideMidPoint3
+    {
+      1_mps,
+      2_mps,
+      0_mps
+    };
+
+    
+    std::vector<units::velocity::meters_per_second_t> redFarSideMidPoint4
+    {
+      1_mps,
+      2_mps,
+      0_mps
+    };
+    
+    std::vector<units::velocity::meters_per_second_t> redFarSideMidPoint5
+    {
+      1_mps,
+      3_mps,
+      0_mps
+    };
+
+
+    std::vector<units::velocity::meters_per_second_t> redFarSideMidCruise1
+    {
+      1_mps,
+      3_mps
+    };
+    
+    std::vector<units::velocity::meters_per_second_t> redFarSideMidCruise2
+    {
+      1_mps,
+      3_mps
+    };
+    
+    std::vector<units::velocity::meters_per_second_t> redFarSideMidCruise3
+    {
+      1_mps,
+      3_mps,
+      3_mps
+    };
+    
+    std::vector<units::velocity::meters_per_second_t> redFarSideMidCruise4
+    {
+      1_mps,
+      3_mps,
+      2_mps
+    };
+    
+    std::vector<units::velocity::meters_per_second_t> redFarSideMidCruise5
     {
       1_mps,
       3_mps,

--- a/src/main/include/RobotContainer.h
+++ b/src/main/include/RobotContainer.h
@@ -50,6 +50,7 @@
 #include "commands/AmpCommand.h"
 #include "commands/AmpShooter.h"
 #include "commands/AmpLineup.h"
+#include "commands/AutoShooterWarmupCmd.h"
 
 /**
  * This class is where the bulk of the robot should be declared.  Since
@@ -67,6 +68,7 @@ class RobotContainer
     float Deadzone(float x); 
     float DeadzoneCubed(float x);
     void ConfigureButtonBindings();
+    void ZeroHeading();
 
   private:
     //replace with frc::Joystick if using a joystick instead of an xbox controller
@@ -312,16 +314,16 @@ class RobotContainer
     std::vector<frc::Pose2d> close4Waypoint2
     {
       frc::Pose2d(2.65_m, 5.55_m, 180_deg),
-      frc::Pose2d(2_m, 6.8_m, 180_deg),
+      frc::Pose2d(2.2_m, 6.8_m, 180_deg),
       frc::Pose2d(2.65_m, 7_m, 180_deg)
     };
 
     std::vector<frc::Pose2d> close4Waypoint3
     {
       frc::Pose2d(2.65_m, 7_m, 180_deg),
-      frc::Pose2d(2_m, 4.3_m, 180_deg),
+      frc::Pose2d(2.2_m, 4.3_m, 180_deg),
       frc::Pose2d(2.6_m, 4.1_m, 180_deg),
-      frc::Pose2d(2.35_m, 4.1_m, 180_deg)
+      frc::Pose2d(2.35_m, 4.1_m, 130_deg)
     };
 
     std::vector<units::meters_per_second_t> close4PointSpeed1
@@ -341,7 +343,7 @@ class RobotContainer
     {
       1_mps,
       1.5_mps,
-      0_mps,
+      1.5_mps,
       0_mps
     };
 

--- a/src/main/include/RobotContainer.h
+++ b/src/main/include/RobotContainer.h
@@ -323,7 +323,7 @@ class RobotContainer
       frc::Pose2d(2.65_m, 7_m, 180_deg),
       frc::Pose2d(2.2_m, 4.3_m, 180_deg),
       frc::Pose2d(2.6_m, 4.1_m, 180_deg),
-      frc::Pose2d(2.35_m, 4.1_m, 130_deg)
+      frc::Pose2d(2.35_m, 4.1_m, -130_deg)
     };
 
     std::vector<units::meters_per_second_t> close4PointSpeed1

--- a/src/main/include/commands/AutoShooterWarmupCmd.h
+++ b/src/main/include/commands/AutoShooterWarmupCmd.h
@@ -1,0 +1,36 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <frc2/command/Command.h>
+#include <frc2/command/CommandHelper.h>
+#include "subsystems/ShooterWheelsSubsystem.h"
+
+/**
+ * An example command.
+ *
+ * <p>Note that this extends CommandHelper, rather extending Command
+ * directly; this is crucially important, or else the decorator functions in
+ * Command will *not* work!
+ */
+class AutoShooterWarmupCmd
+    : public frc2::CommandHelper<frc2::Command, AutoShooterWarmupCmd>\
+{
+  public:
+    AutoShooterWarmupCmd();
+    AutoShooterWarmupCmd(ShooterWheelsSubsystem &shooterWheels);
+
+    void Initialize() override;
+
+    void Execute() override;
+
+    void End(bool interrupted) override;
+
+    bool IsFinished() override;
+
+  private:
+    ShooterWheelsSubsystem* m_shooterWheel = nullptr;
+
+};

--- a/src/main/include/commands/AutoSubAim.h
+++ b/src/main/include/commands/AutoSubAim.h
@@ -1,0 +1,38 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+#pragma once
+
+#include <frc2/command/Command.h>
+#include <frc2/command/CommandHelper.h>
+
+#include "subsystems/ShooterSubsystem.h"
+
+/**
+ * An example command.
+ *
+ * <p>Note that this extends CommandHelper, rather extending Command
+ * directly; this is crucially important, or else the decorator functions in
+ * Command will *not* work!
+ */
+class AutoSubAim
+    : public frc2::CommandHelper<frc2::Command, AutoSubAim> {
+ public:
+  AutoSubAim();
+  AutoSubAim(ShooterSubsystem &shooter);
+
+  void Initialize() override;
+
+  void Execute() override;
+
+  void End(bool interrupted) override;
+
+  bool IsFinished() override;
+
+ private:
+  ShooterSubsystem* m_shooter;
+
+  int time = 0;
+  bool timeIsUp = false;
+};


### PR DESCRIPTION
Pretty nasty PR - I can only speak to what I helped Callie and Mikaela on.

Once this is merged to main, everything will be in main. A feature branch created off main once this is merged in will have everything. Amp April Tag Auto is not going to be faster than Ian's manual practice. even with the ideas I've suggested to improve the april tag. It fell in priority to Auto, anyway. I'll have Callie clean up any April Tag Amp code that's residual, if there is any. 


(some of the) Things this PR covers:
- Removed unneeded Auto paths
- "Just Shoot Center" is now a test path for testing the initial heading, drive direction, and heading reset from auto to teleop. It shots backs up, and that's about it.
- Switched the amp controls from driver to aux controller. Driver still shoots for the amp, however.
- Zero heading at the START of auto, with the robot being rotated 180 (facing alliance wall) - This should work correctly. Removed the "2 *" thing for the offset. it's not needed.
- Started RedFarSideMid path, DO NOT RUN IT - SEE NOTES IN CODE. IT NEEDS WAYPOINTS TO BE UPDATED
- Removed "amparm" from smart dashboard


Things that still need to be done:
-Autopaths should have more consistent, better names. See code for possible names.
-RedFarSideMid and RedSide4Note path needs its waypoint values updated.
-Blue and Red Amp side auto path needs to be created.
-Blue side 4 note and blueFarSideMid should be tested and determined if they need to be honed in (the driving path - not the shooting - that's kinda a mess)
- Remove unneeded poses from GetAutonomousCommand in Robot Container.
- Remove dead code from Robot Container.
- Add Zero Heading to start of all autos - see "JustShootingCenter" as an example. 
(Then all auto paths need to be tested to verify the heading in tele is working after auto.

NOTE: The proper way to test this is EXACTLY like the tournament:
1. Set the robot down where you want it
2. Power it on
3. Choose your auto path
4. Run the practice and let it switch to tele
5. test heading to make sure it's correct.

ANYTHING other than that isn't a test and may give you false positives. (For example - if you set the heading correctly and then run auto, of course heading will be correct, etc)